### PR TITLE
Added evaluation of evaluators in macros

### DIFF
--- a/multiwindcalc/parsers/value_proxy.py
+++ b/multiwindcalc/parsers/value_proxy.py
@@ -156,8 +156,11 @@ class ValueProxyParser:
         :type value_libraries: dict
         """
         self._evaluator_library = value_libraries.get(EVALUATOR, {})
-        self._macro_library = value_libraries.get(MACRO, {})
         self._generator_library = value_libraries.get(GENERATOR, {})
+        # resolve macros that are evaluators or generators into ValueProxies
+        self._macro_library = {}
+        for k, v in value_libraries.get(MACRO, {}).items():
+            self._macro_library[k] = self.parse(v.evaluate()) if self.is_value_proxy(v.evaluate()) else v
 
     def parse(self, value):
         """Parse the value string

--- a/tests/parsers/specification_parser_tests.py
+++ b/tests/parsers/specification_parser_tests.py
@@ -322,6 +322,25 @@ def test_can_produce_range_of_items_stopped_at_macro():
     properties = [l.collected_properties for l in root_node.leaves]
     assert expected == properties
 
+def test_can_use_properties_from_evaluator_in_macro_in_spec_evaluator():
+    provider = DictSpecificationProvider({
+        'macros': {
+            'MyRange': '#range(2, 5, 2)'
+        },
+        'spec': {
+            'alpha': '$MyRange',
+            'beta': '#4 + !alpha'
+        }
+    })
+    parser = SpecificationParser(provider)
+    root_node = parser.parse().root_node
+    expected = [
+        {'alpha': 2, 'beta': 6},
+        {'alpha': 4, 'beta': 8}
+    ]
+    properties = [l.collected_properties for l in root_node.leaves]
+    assert expected == properties
+
 def test_can_do_multiplication_with_evaluator():
     root_node = DefaultSpecificationNodeParser(value_libraries={'eval': {'mult': MultiplyEvaluator}, 'macro': {'vref': Macro(4)}}).parse({
         'wind_speed': '#5 * 3',


### PR DESCRIPTION
I sorted this at least for the simple test case. There were a couple of places this could have been but the `ValueProxyParser` seems the best place as it has the overview of how generators, evaluators and macros (potentially) interact.