### PR TITLE
Fixing issue with copying IndexedNode

### DIFF
--- a/spawn/specification/specification.py
+++ b/spawn/specification/specification.py
@@ -324,6 +324,24 @@ class SpecificationNode:
         """
         for child in self._children:
             child.evaluate()
+        
+    def copy(self, new_parent):
+        """Copies this node and this node's children
+
+        :param new_parent: The new parent node
+        :type new_parent: :class:`SpecificationNode`
+
+        :returns: A copy of this node
+        :rtype: :class:`SpecificationNode`
+        """
+        new_node = self._initialise_copy(new_parent)
+        for child in self.children:
+            new_child = child.copy(new_node)
+            new_node.add_child(new_child)
+        return new_node
+    
+    def _initialise_copy(self, new_parent):
+        return type(self)(new_parent, self.property_name, self.property_value, self._path_part, self._ghosts)
     
     def _climb(self, f):
         current_node = self
@@ -355,6 +373,9 @@ class IndexedNode(SpecificationNode):
         this node has a property
         """
         return True
+    
+    def _initialise_copy(self, new_parent):
+        return type(self)(new_parent, self.property_name, self._index, self.property_value, self._path_part, self._ghosts)
 
 class ValueProxyNode(SpecificationNode):
     def __init__(self, parent, name, value_proxy, path, ghosts):
@@ -438,11 +459,7 @@ class SpecificationNodeFactory:
         return node
     
     def _copy_tree(self, parent, node):
-        new_node = type(node)(parent, node.property_name, node.property_value, node._path_part, node._ghosts)
-        for child in node.children:
-            new_child = self._copy_tree(new_node, child)
-            new_node.add_child(new_child)
-        return new_node
+        return node.copy(parent)
     
     @staticmethod
     def _index(name):

--- a/tests/parsers/specification_parser_tests.py
+++ b/tests/parsers/specification_parser_tests.py
@@ -659,3 +659,19 @@ def test_adding_index_property_produces_index_node():
     assert root_node.leaves[0].index == 1
     assert root_node.leaves[0].property_name == 'pitch'
     assert root_node.leaves[0].property_value == 2.3
+
+def test_can_have_multiple_indexed_properties_with_one_being_a_macro(plugin_loader):
+    provider = DictSpecificationProvider({
+        'macros': {
+            'Value': 4.0
+        },
+        'spec': {
+            'blah': {
+                'alpha[1]': '$Value',
+                'beta[1]': 6
+            }
+        }
+    })
+    parser = SpecificationParser(provider, plugin_loader)
+    root_node = parser.parse().root_node
+    assert isinstance(root_node.leaves[0], IndexedNode)


### PR DESCRIPTION
Allow the copy constructor to be overloaded in `SpecificationNode`, and provide the missing argument in `IndexedNode`

Closes #71 