### PR TITLE
JSON spawner

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -247,6 +247,7 @@ good-names=i,
            k,
            v,
            fp,
+           fw,
            ex,
            Run,
            _

--- a/.pylintrc
+++ b/.pylintrc
@@ -139,7 +139,7 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
         unnecessary-comprehension
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -140,6 +140,7 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape
+        unnecessary-comprehension
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/spawn/__init__.py
+++ b/spawn/__init__.py
@@ -26,9 +26,14 @@ spawn root module
 __copyright__ = 'Copyright (C) 2018, Simmovation Ltd.'
 __author__ = 'Simmovation Ltd.'
 
+from .plugins import json_input_file as json_plugin
+from .plugins import PluginLoader
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
 # Default `run` and `inspect` should be local
 from .interface import run_local as run, inspect_local as inspect, write_inspection
+
+# Load built-in plugins
+PluginLoader.pre_load_plugin('json', json_plugin)

--- a/spawn/interface/local.py
+++ b/spawn/interface/local.py
@@ -17,7 +17,7 @@
 """Defines the local implementation of :class:`SpawnInterface`
 """
 import logging
-from os import path
+from os import path, makedirs
 import json
 
 from spawn.plugins import PluginLoader
@@ -79,13 +79,18 @@ class LocalInterface(SpawnInterface):
                 'No plugin type defined - please specify the --type argument ' +
                 'or add a type property in the spec file'
             ))
+        self._write_json_inspection_file(spec, self._config.get(self._config.default_category, 'outdir'))
         spawner = self._plugin_loader.create_spawner(plugin_type)
         scheduler = LuigiScheduler(self._config)
-        inspection_file = path.join(self._config.get(self._config.default_category, 'outdir'), 'spawn.json')
+        scheduler.run(spawner, spec)
+
+    def _write_json_inspection_file(self, spec, outdir):
+        if not path.isdir(outdir):
+            makedirs(outdir)
+        inspection_file = path.join(outdir, 'spawn.json')
         LOGGER.info('Writing inspection to %s', inspection_file)
         with open(inspection_file, 'w') as fp:
             json.dump(self._spec_to_spec_dict(spec), fp, indent=2)
-        scheduler.run(spawner, spec)
 
     def _spec_dict_to_spec(self, spec_dict):
         return SpecificationParser(self._plugin_loader).parse(spec_dict)

--- a/spawn/plugins/json_input_file.py
+++ b/spawn/plugins/json_input_file.py
@@ -1,0 +1,70 @@
+# spawn
+# Copyright (C) 2018-2019, Simmovation Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+"""Plugin for running tasks that take a single JSON input file as command line argument
+"""
+import json
+import logging
+
+from luigi import configuration
+
+from ..util.validation import validate_file, validate_dir
+from ..spawners import SingleInputFileSpawner
+from ..tasks import SimulationTask
+from ..simulation_inputs import JsonSimulationInput
+
+
+def create_spawner(task_exe, working_dir, base_file, runner_type):
+    """
+    Creates spawner that creates tasks taking a single JSON input file as command line argument
+
+    :param task_exe: Path of executable to run. If None, input files will be written but no tasks run
+    :param working_dir: Working directory of task execution
+    :param base_file: Baseline JSON file on which to make parameter editions and additions. If None, parameter additions
+     will be made onto an empty input
+    :return: :class:`SingleInputFileSpawner` object
+    """
+    if task_exe is not None:
+        validate_file(task_exe, 'task_exe')
+    if working_dir is not None:
+        validate_dir(working_dir, 'working_dir')
+    if base_file is not None:
+        validate_file(base_file, 'base_file')
+
+    if task_exe is None:
+        task_exe = ''
+    if working_dir is None:
+        working_dir = '.'
+
+    logger = logging.getLogger(__name__)
+    logger.info("Creating Single input file spawner with JSON input")
+    logger.info("task_exe = %s", task_exe)
+    logger.info("working_dir = %s", working_dir)
+    logger.info("base_file = %s", base_file)
+    logger.info("runner_type = %s", runner_type)
+
+    luigi_config = configuration.get_config()
+    luigi_config.set(SimulationTask.__name__, '_exe_path', task_exe)
+    luigi_config.set(SimulationTask.__name__, '_working_dir', working_dir)
+    luigi_config.set(SimulationTask.__name__, '_runner_type', runner_type)
+
+    if base_file is not None:
+        with open(base_file, 'r') as fp:
+            params = json.load(fp)
+    else:
+        params = {}
+    sim_input = JsonSimulationInput(params, indent=2)
+    return SingleInputFileSpawner(sim_input, 'input.json')

--- a/spawn/runners/process_runner.py
+++ b/spawn/runners/process_runner.py
@@ -63,7 +63,7 @@ class ProcessRunner:
         validate_file(self._input_file_path, 'input_file_path')
         validate_file(self._exe_path, 'exe_path')
         LOGGER.info('Executing \'%s\': %s', self._id, self.process_args)
-        output = subprocess.run(args=self.process_args, cwd=self._cwd,
+        output = subprocess.run(args=self.process_args, cwd=self._cwd, check=False,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self._write_logs(output)
         state = self._output_to_state(output)

--- a/spawn/simulation_inputs/__init__.py
+++ b/spawn/simulation_inputs/__init__.py
@@ -19,3 +19,4 @@
 An input a class that reads and writes parameter values, normally to a file
 """
 from .simulation_input import SimulationInput
+from .json import JsonSimulationInput

--- a/spawn/simulation_inputs/json.py
+++ b/spawn/simulation_inputs/json.py
@@ -58,6 +58,7 @@ class JsonSimulationInputView(SimulationInput):
 class JsonSimulationInput(JsonSimulationInputView):
     """A dictionary input written as a JSON file where the parameter set is deep copied"""
 
+    # pylint: disable=super-init-not-called
     def __init__(self, parameter_set, **write_options):
         """Create a instance of :class:`JsonSimulationInput`
 

--- a/spawn/simulation_inputs/json.py
+++ b/spawn/simulation_inputs/json.py
@@ -21,8 +21,8 @@ import copy
 from .simulation_input import SimulationInput
 
 
-class JsonSimulationInput(SimulationInput):
-    """A dictionary input written as a JSON file"""
+class JsonSimulationInputView(SimulationInput):
+    """A dictionary input written as a JSON file where the parameter set is not deep-copied"""
 
     def __init__(self, parameter_set, **write_options):
         """Create a instance of :class:`JsonSimulationInput`
@@ -30,7 +30,7 @@ class JsonSimulationInput(SimulationInput):
         :param parameter_set: Baseline parameter set
         :type parameter_set: dict
         """
-        self._parameter_set = copy.deepcopy(parameter_set)
+        self._parameter_set = parameter_set
         self._write_options = write_options
 
     @classmethod
@@ -49,4 +49,20 @@ class JsonSimulationInput(SimulationInput):
         self._parameter_set.__setitem__(key, value)
 
     def __getitem__(self, item):
-        return self._parameter_set.__getitem__(item)
+        obj = self._parameter_set.__getitem__(item)
+        if isinstance(obj, dict):
+            return JsonSimulationInputView(obj, **self._write_options)
+        return obj
+
+
+class JsonSimulationInput(JsonSimulationInputView):
+    """A dictionary input written as a JSON file where the parameter set is deep copied"""
+
+    def __init__(self, parameter_set, **write_options):
+        """Create a instance of :class:`JsonSimulationInput`
+
+        :param parameter_set: Baseline parameter set (deep copied)
+        :type parameter_set: dict
+        """
+        self._parameter_set = copy.deepcopy(parameter_set)
+        self._write_options = write_options

--- a/spawn/simulation_inputs/json.py
+++ b/spawn/simulation_inputs/json.py
@@ -1,3 +1,20 @@
+# spawn
+# Copyright (C) 2018-2019, Simmovation Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+"""Concrete implementation of :class:`SimulationInput` that writes JSON files"""
 import json
 import copy
 

--- a/spawn/simulation_inputs/json.py
+++ b/spawn/simulation_inputs/json.py
@@ -1,0 +1,35 @@
+import json
+import copy
+
+from .simulation_input import SimulationInput
+
+
+class JsonSimulationInput(SimulationInput):
+    """A dictionary input written as a JSON file"""
+
+    def __init__(self, parameter_set, **write_options):
+        """Create a instance of :class:`JsonSimulationInput`
+
+        :param parameter_set: Baseline parameter set
+        :type parameter_set: dict
+        """
+        self._parameter_set = copy.deepcopy(parameter_set)
+        self._write_options = write_options
+
+    @classmethod
+    def from_file(cls, file_path):
+        with open(file_path, 'r') as fp:
+            return cls(json.load(fp))
+
+    def to_file(self, file_path):
+        with open(file_path, 'w') as fw:
+            json.dump(self._parameter_set, fw, **self._write_options)
+
+    def hash(self):
+        return hash(json.dumps(self._parameter_set))
+
+    def __setitem__(self, key, value):
+        self._parameter_set.__setitem__(key, value)
+
+    def __getitem__(self, item):
+        return self._parameter_set.__getitem__(item)

--- a/spawn/spawners/__init__.py
+++ b/spawn/spawners/__init__.py
@@ -19,3 +19,4 @@
 Task spawners turn specification nodes into tasks that can be submitted by a scheduler
 """
 from .task_spawner import TaskSpawner
+from .single_input_file import SingleInputFileSpawner

--- a/spawn/spawners/single_input_file.py
+++ b/spawn/spawners/single_input_file.py
@@ -16,7 +16,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 """Spawner implementation that spawns :class:`SimulationTask`s taking a single input file path as its only command line
  argument"""
-from os import path
+from os import path, makedirs
 import copy
 
 from ..tasks import SimulationTask
@@ -43,6 +43,8 @@ class SingleInputFileSpawner(TaskSpawner):
         self.__dict__['__file_name'] = file_name
 
     def spawn(self, path_, metadata):
+        if not path.isdir(path_):
+            makedirs(path_)
         input_file_path = path.join(path_, self.__dict__['__file_name'])
         self.__dict__['__simulation_input'].to_file(input_file_path)
         return SimulationTask(_id=path_,

--- a/spawn/spawners/single_input_file.py
+++ b/spawn/spawners/single_input_file.py
@@ -54,6 +54,7 @@ class SingleInputFileSpawner(TaskSpawner):
 
     def __getattr__(self, item):
         if item.startswith('__') and item.endswith('__'):
+            # pylint: disable=no-member
             return super().__getattr__(item)
         return self.__dict__['__simulation_input'][item]
 

--- a/spawn/spawners/single_input_file.py
+++ b/spawn/spawners/single_input_file.py
@@ -22,12 +22,10 @@ import copy
 from ..tasks import SimulationTask
 from ..simulation_inputs import SimulationInput
 from .task_spawner import TaskSpawner
-from ..util import TypedProperty
 
 
 class SingleInputFileSpawner(TaskSpawner):
     """Runs bespoke executable taking a single input file as its only command line argument"""
-    aa = TypedProperty(float)
 
     def __init__(self, simulation_input, file_name):
         """Create a instance of :class:`SingleInputFileSpawner`

--- a/spawn/spawners/single_input_file.py
+++ b/spawn/spawners/single_input_file.py
@@ -1,0 +1,33 @@
+from os import path
+import copy
+
+from ..tasks import SimulationTask
+from ..simulation_inputs import SimulationInput
+from .task_spawner import TaskSpawner
+
+
+class SingleInputFileSpawner(TaskSpawner):
+    """Runs bespoke executable taking a single input file as its only command line argument"""
+
+    def __init__(self, simulation_input, file_name):
+        """Create a instance of :class:`SingleInputFileSpawner`
+
+        :param simulation_input: Simulation input file write
+        :type simulation_input: :class:`SimulationInput`
+        :param file_name: Name of input file for simulation, including extension but excluding path
+        :type file_name: str
+        """
+        if not isinstance(simulation_input, SimulationInput):
+            raise TypeError("simulation_input must be of type SimulationInput")
+        self._simulation_input = simulation_input
+        self._file_name = file_name
+
+    def spawn(self, path_, metadata):
+        input_file_path = path.join(path_, self._file_name)
+        self._simulation_input.to_file(input_file_path)
+        return SimulationTask(_id=path_,
+                              _input_file_path=input_file_path,
+                              _metadata=metadata)
+
+    def branch(self):
+        return SingleInputFileSpawner(copy.deepcopy(self._simulation_input), self._file_name)

--- a/spawn/spawners/single_input_file.py
+++ b/spawn/spawners/single_input_file.py
@@ -1,3 +1,21 @@
+# spawn
+# Copyright (C) 2018-2019, Simmovation Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+"""Spawner implementation that spawns :class:`SimulationTask`s taking a single input file path as its only command line
+ argument"""
 from os import path
 import copy
 

--- a/spawn/spawners/task_spawner.py
+++ b/spawn/spawners/task_spawner.py
@@ -20,7 +20,7 @@
 class TaskSpawner:
     """Base class task spawner"""
 
-    def spawn(self, path, metadata):
+    def spawn(self, path_, metadata):
         """Create new derivative of luigi.Task for later execution"""
         raise NotImplementedError()
 

--- a/spawn/tasks/simulation.py
+++ b/spawn/tasks/simulation.py
@@ -39,7 +39,8 @@ class SimulationTask(SpawnTask):
     def run(self):
         """Run this task
         """
-        self._create_runner().run()
+        if self._exe_path:
+            self._create_runner().run()
 
     def complete(self):
         """Determine if this task is complete
@@ -47,6 +48,8 @@ class SimulationTask(SpawnTask):
         :returns: ``True`` if this task is complete; otherwise ``False``
         :rtype: bool
         """
+        if not self._exe_path:
+            return True
         return self._create_runner().complete()
 
     def on_failure(self, exception):

--- a/tests/plugins/json_plugin_tests.py
+++ b/tests/plugins/json_plugin_tests.py
@@ -1,0 +1,25 @@
+import json
+from os import path
+
+from luigi import configuration
+
+from spawn.plugins.json_input_file import create_spawner
+from spawn.tasks import SimulationTask
+
+
+def test_when_creating_spawner_simulation_task_parameters_are_set_correctly(example_data_folder, tmpdir):
+    fake_exe_path = __file__
+    create_spawner(fake_exe_path, str(tmpdir), path.join(example_data_folder, 'example_spec.json'), 'process')
+    luigi_config = configuration.get_config()
+    assert fake_exe_path == luigi_config.get(SimulationTask.__name__, '_exe_path')
+    assert tmpdir == luigi_config.get(SimulationTask.__name__, '_working_dir')
+    assert 'process' == luigi_config.get(SimulationTask.__name__, '_runner_type')
+
+
+def test_spawner_uses_correct_base_file(tmpdir):
+    fake_exe_path = __file__
+    base_file = path.join(tmpdir, 'base.json')
+    with open(base_file, 'w') as fw:
+        json.dump({'alpha': 'egg'}, fw)
+    spawner = create_spawner(fake_exe_path, str(tmpdir), base_file, 'process')
+    assert 'egg' == spawner.alpha

--- a/tests/plugins/plugin_loader_tests.py
+++ b/tests/plugins/plugin_loader_tests.py
@@ -73,6 +73,7 @@ def test_load_generators_finds_all_generators(plugin_loader):
 
 def test_load_generators_finds_correct_evaluators(plugin_loader):
     evaluators = plugin_loader.load_evaluators()
-    assert set(evaluators.keys()) == {'spawn_evaluator', 'multiply_evaluator'}
+    assert 'spawn_evaluator' in evaluators
+    assert 'multiply_evaluator' in evaluators
     assert evaluators['spawn_evaluator']().evaluate() == 'spawn'
     assert evaluators['multiply_evaluator'](42, 3).evaluate() == 126

--- a/tests/simulation_inputs/json_tests.py
+++ b/tests/simulation_inputs/json_tests.py
@@ -28,7 +28,8 @@ def test_write_read_round_trip(tmpdir, params):
     inp.to_file(fp)
     inp2 = JsonSimulationInput.from_file(fp)
     assert params['a'] == inp2['a']
-    assert params['b'] == inp2['b']
+    assert params['b']['c'] == inp2['b']['c']
+    assert params['b']['d'] == inp2['b']['d']
 
 
 def test_deepcopy_unlinks_inputs(params):

--- a/tests/simulation_inputs/json_tests.py
+++ b/tests/simulation_inputs/json_tests.py
@@ -1,3 +1,19 @@
+# spawn
+# Copyright (C) 2018, Simmovation Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 import pytest
 from os import path
 import copy

--- a/tests/simulation_inputs/json_tests.py
+++ b/tests/simulation_inputs/json_tests.py
@@ -1,0 +1,53 @@
+import pytest
+from os import path
+import copy
+
+from spawn.simulation_inputs.json import JsonSimulationInput
+
+
+@pytest.fixture()
+def params():
+    return {
+        'a': 3,
+        'b': {
+            'c': 'egg',
+            'd': 'tadpole'
+        }
+    }
+
+
+def test_set_get(params):
+    inp = JsonSimulationInput(params)
+    inp['a'] = 4
+    assert 4 == inp['a']
+
+
+def test_write_read_round_trip(tmpdir, params):
+    inp = JsonSimulationInput(params, indent=2)
+    fp = path.join(tmpdir, 'file.json')
+    inp.to_file(fp)
+    inp2 = JsonSimulationInput.from_file(fp)
+    assert params['a'] == inp2['a']
+    assert params['b'] == inp2['b']
+
+
+def test_deepcopy_unlinks_inputs(params):
+    a = JsonSimulationInput(params)
+    b = copy.deepcopy(a)
+    b['a'] = 5
+    a['b']['c'] = 'frog'
+    assert params['a'] == a['a']
+    assert params['b']['c'] == b['b']['c']
+
+
+def test_hash_is_same_for_same_inputs(params):
+    a = JsonSimulationInput(params)
+    b = JsonSimulationInput(params)
+    assert a.hash() == b.hash()
+
+
+def test_hash_is_different_for_diferent_inputs(params):
+    a = JsonSimulationInput(params)
+    params['b']['d'] = 'frog'
+    b = JsonSimulationInput(params)
+    assert a.hash() != b.hash()

--- a/tests/spawners/single_input_file_tests.py
+++ b/tests/spawners/single_input_file_tests.py
@@ -39,7 +39,8 @@ def test_spawn_writes_input_file(sim_input, tmpdir, set_config):
 def test_branched_spawner_spawns_different_file(sim_input, tmpdir, set_config):
     spawner = SingleInputFileSpawner(sim_input, 'input.json')
     branch = spawner.branch()
-    branch
+    branch.a = 'frog'
+    # branch.b.c = 'tadpole'
     mkdir(path.join(tmpdir, 'a'))
     mkdir(path.join(tmpdir, 'b'))
     spawner.spawn(path.join(tmpdir, 'a'), {})
@@ -48,4 +49,4 @@ def test_branched_spawner_spawns_different_file(sim_input, tmpdir, set_config):
         a = json.load(fp)
     with open(path.join(tmpdir, 'b', 'input.json'), 'r') as fp:
         b = json.load(fp)
-        assert a != b
+    assert a != b

--- a/tests/spawners/single_input_file_tests.py
+++ b/tests/spawners/single_input_file_tests.py
@@ -1,0 +1,51 @@
+from os import path, mkdir
+import json
+
+import pytest
+from luigi import configuration
+
+from spawn.spawners import SingleInputFileSpawner
+from spawn.simulation_inputs import JsonSimulationInput
+from spawn.tasks import SimulationTask
+
+
+@pytest.fixture()
+def sim_input():
+    params = {
+        'a': 'tadpole',
+        'b': {
+            'c': 'egg',
+            'd': 'frog'
+        }
+    }
+    return JsonSimulationInput(params)
+
+
+@pytest.fixture(scope='module')
+def set_config():
+    luigi_config = configuration.get_config()
+    luigi_config.set(SimulationTask.__name__, '_runner_type', 'process')
+    luigi_config.set(SimulationTask.__name__, '_exe_path', '')
+
+
+def test_spawn_writes_input_file(sim_input, tmpdir, set_config):
+    spawner = SingleInputFileSpawner(sim_input, 'input.json')
+    spawner.spawn(tmpdir, {})
+    with open(path.join(tmpdir, 'input.json'), 'r') as fp:
+        params = json.load(fp)
+    assert params['a'] == 'tadpole'
+
+
+def test_branched_spawner_spawns_different_file(sim_input, tmpdir, set_config):
+    spawner = SingleInputFileSpawner(sim_input, 'input.json')
+    branch = spawner.branch()
+    branch
+    mkdir(path.join(tmpdir, 'a'))
+    mkdir(path.join(tmpdir, 'b'))
+    spawner.spawn(path.join(tmpdir, 'a'), {})
+    branch.spawn(path.join(tmpdir, 'b'), {})
+    with open(path.join(tmpdir, 'a', 'input.json'), 'r') as fp:
+        a = json.load(fp)
+    with open(path.join(tmpdir, 'b', 'input.json'), 'r') as fp:
+        b = json.load(fp)
+        assert a != b

--- a/tests/spawners/single_input_file_tests.py
+++ b/tests/spawners/single_input_file_tests.py
@@ -1,3 +1,19 @@
+# spawn
+# Copyright (C) 2018, Simmovation Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 from os import path, mkdir
 import json
 

--- a/tests/spawners/single_input_file_tests.py
+++ b/tests/spawners/single_input_file_tests.py
@@ -40,7 +40,6 @@ def test_branched_spawner_spawns_different_file(sim_input, tmpdir, set_config):
     spawner = SingleInputFileSpawner(sim_input, 'input.json')
     branch = spawner.branch()
     branch.a = 'frog'
-    # branch.b.c = 'tadpole'
     mkdir(path.join(tmpdir, 'a'))
     mkdir(path.join(tmpdir, 'b'))
     spawner.spawn(path.join(tmpdir, 'a'), {})
@@ -50,3 +49,4 @@ def test_branched_spawner_spawns_different_file(sim_input, tmpdir, set_config):
     with open(path.join(tmpdir, 'b', 'input.json'), 'r') as fp:
         b = json.load(fp)
     assert a != b
+    assert b['a'] == 'frog'


### PR DESCRIPTION
Creating an inbuilt JSON plugin which uses:
* `SingleInputFileSpawner` which is a simple spawner, spawning tasks that take one input file as argument. Sets attributes through a `SimulationInput` object
* A `JsonSimulationInput` object which sets items into a dictionary and writes to a JSON file.
The JSON plugin creates a `SingleInputFileSpawner` which uses a `JsonSimulationInput`.

Change to `SimulationTask` so that in case the `_exe_path` is empty, simulations are not run (but a spawner will still do preceding actions such as writing input files.