### PR TITLE
Immutable value proxies

### DIFF
--- a/spawn/config/ini_file.py
+++ b/spawn/config/ini_file.py
@@ -30,7 +30,9 @@ class IniFileConfiguration(ConfigurationBase):
         :param ini_file: The file to read
         :type ini_file: path-like
         """
-        self._config = configparser.ConfigParser() if ini_file and path.isfile(ini_file) else None
+        if ini_file and not path.isfile(ini_file):
+            raise OSError("Could not find ini file '{}'".format(ini_file))
+        self._config = configparser.ConfigParser() if ini_file else None
         if self._config:
             self._config.read(ini_file)
 

--- a/spawn/parsers/generators.py
+++ b/spawn/parsers/generators.py
@@ -16,6 +16,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 """This module defines the generator parser
 """
+import copy
 import inspect
 from ..specification import generator_methods
 from ..util.validation import validate_type
@@ -45,8 +46,8 @@ class GeneratorsParser:
             if 'method' not in gen:
                 raise KeyError("Generator '{}' missing 'method'".format(name))
             method = gen['method']
-            del gen['method']
-            generator_objects[name] = self._instantiate(method, gen)
+            gen_args = {k: v for k, v in gen.items() if k != 'method'}
+            generator_objects[name] = self._instantiate(method, gen_args)
         return generator_objects
 
     def _instantiate(self, method, args):

--- a/spawn/parsers/generators.py
+++ b/spawn/parsers/generators.py
@@ -16,7 +16,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 """This module defines the generator parser
 """
-import copy
 import inspect
 from ..specification import generator_methods
 from ..util.validation import validate_type

--- a/spawn/parsers/macros.py
+++ b/spawn/parsers/macros.py
@@ -16,6 +16,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 """This module defines the generator parser
 """
+import copy
+
 from spawn.specification.value_proxy import Macro, ValueProxy
 
 from .value_proxy import ValueProxyParser
@@ -51,6 +53,7 @@ class MacrosParser:
         :returns: An dict containing the values for the specified macros.
         :rtype: dict
         """
+        macros = copy.deepcopy(macros)  # deep copy so that popping doesn't remove macros for any future parsings
         if macros is None:
             return {}
         validate_type(macros, dict, 'macros')

--- a/spawn/util/property.py
+++ b/spawn/util/property.py
@@ -22,6 +22,9 @@ import functools
 
 from spawn.util.validation import validate_type
 
+def _not_implemented_message(obj, name, problem):
+    return "'{}' {} in '{}'".format(name, problem, obj.__class__.__name__)
+
 def typed_property(type_):
     """Function decorator for :class:`TypedProperty`
     """
@@ -165,7 +168,7 @@ class TypedProperty(PropertyBase):
         if self._fget:
             return self._fget(obj)
         if self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         return obj.__dict__.get(self._name, self._default)
 
     def __set__(self, obj, value):
@@ -174,7 +177,7 @@ class TypedProperty(PropertyBase):
         if self._name is None:
             raise ValueError('Cannot set property, name has not been set')
         if self._readonly:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "cannot be set because it's read-only"))
         self._validate(obj, value)
         if hasattr(obj, self._get_fname('validate')):
             getattr(obj, self._get_fname('validate'))(value)
@@ -185,7 +188,7 @@ class TypedProperty(PropertyBase):
         elif self._fset:
             self._fset(obj, value)
         elif self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         else:
             obj.__dict__[self._name] = value
 
@@ -197,7 +200,7 @@ class TypedProperty(PropertyBase):
         elif self._fdel:
             self._fdel(obj)
         elif self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         else:
             del obj.__dict__[self._name]
 
@@ -371,7 +374,7 @@ class ArrayProperty(PropertyBase):
         if self._name is None:
             raise ValueError('Cannot get property, name has not been set')
         if self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         return self._wrapper(obj)
 
     def __set__(self, obj, value):
@@ -380,7 +383,7 @@ class ArrayProperty(PropertyBase):
         if self._name is None:
             raise ValueError('Cannot set property, name has not been set')
         if self._readonly or self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         validate_type(value, list, 'value')
         wrapper = self._wrapper(obj)
         for i, v in enumerate(value):
@@ -392,7 +395,7 @@ class ArrayProperty(PropertyBase):
         if hasattr(obj, self._get_fname('delete')):
             getattr(obj, self._get_fname('delete'))()
         if self._abstract:
-            raise NotImplementedError()
+            raise NotImplementedError(_not_implemented_message(obj, self._name, "not implemented (abstract)"))
         if self._fget or self._fset or self._fdel:
             raise ValueError('Cannot delete array with custom getters and setters')
         del obj.__dict__[self._name]


### PR DESCRIPTION
The inspect command parses the specification twice (stats and inspection), which is a bit dumb but should not cause problems per se. However, it the specification parser changes macro and generator objects because it doesn't deep-copy before making changes. This would cause the second parsing of the specification to fail.