### PR TITLE
Scipy generator methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: run tests
           command: |
             . .venv/bin/activate
-            tox -e py37,docs
+            tox -e py37,docs -r
 
       - save_cache:
           paths:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ tests_require = [
     'numpy',
     'pandas',
     'tox',
-    'licensify'
+    'licensify',
+    'scipy'
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ tests_require = [
     'pandas',
     'tox',
     'licensify',
-    'scipy==1.4.0'
+    'scipy'
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ tests_require = [
     'pandas',
     'tox',
     'licensify',
-    'scipy'
+    'scipy==1.4.0'
 ]
 
 extras_require = {

--- a/spawn/parsers/generators.py
+++ b/spawn/parsers/generators.py
@@ -52,6 +52,8 @@ class GeneratorsParser:
     def _instantiate(self, method, args):
         if method in self._generators:
             return self._generators[method](**args)
+        if method.startswith('scipy.'):
+            return self._generators['ScipyDistribution'](method[len('scipy.'):], **args)
         raise KeyError("Method '" + method + "' not found in generator methods")
 
     @staticmethod

--- a/spawn/specification/generator_methods.py
+++ b/spawn/specification/generator_methods.py
@@ -79,7 +79,7 @@ class IncrementalInt(Generator):
 
 class ScipyDistribution(Generator):
     """Generator of values from a statistical distribution in scipy.stats module"""
-    def __init__(self, distribution, **kwargs):
+    def __init__(self, distribution, random_state=None, **kwargs):
         """Initialises :class:`ScipyDistribution`
 
         :param distribution: Name of statistical function that exists in scipy.stats
@@ -93,7 +93,8 @@ class ScipyDistribution(Generator):
         if not hasattr(scipy_stats_module, distribution):
             raise KeyError("'{}' distribution not found in scipy.stats module")
         self._distribution = getattr(scipy_stats_module, distribution)(**kwargs)
+        self._random_state = import_module('numpy.random').RandomState(random_state)
 
     def evaluate(self):
         """Call `rvs` method of statistical function"""
-        return self._distribution.rvs()
+        return self._distribution.rvs(random_state=self._random_state)

--- a/spawn/specification/generator_methods.py
+++ b/spawn/specification/generator_methods.py
@@ -91,7 +91,7 @@ class ScipyDistribution(Generator):
             raise ImportError("The scipy module is not installed and therefore the 'scipy.{}'"
                               " generator cannot be created".format(distribution)) from ex
         if not hasattr(scipy_stats_module, distribution):
-            raise ValueError("'{}' distribution not found in scipy.stats module")
+            raise KeyError("'{}' distribution not found in scipy.stats module")
         self._distribution = getattr(scipy_stats_module, distribution)(**kwargs)
 
     def evaluate(self):

--- a/spawn/specification/generator_methods.py
+++ b/spawn/specification/generator_methods.py
@@ -17,7 +17,6 @@
 """Generator methods
 """
 import random
-from importlib import import_module
 from spawn.specification.value_proxy import ValueProxy
 
 
@@ -86,14 +85,15 @@ class ScipyDistribution(Generator):
         :param kwargs: Arguments to creation of statistical function
         """
         try:
-            scipy_stats_module = import_module('scipy.stats')
+            from numpy import random
+            from scipy import stats as scipy_stats
         except ImportError as ex:
             raise ImportError("The scipy module is not installed and therefore the 'scipy.{}'"
                               " generator cannot be created".format(distribution)) from ex
-        if not hasattr(scipy_stats_module, distribution):
-            raise KeyError("'{}' distribution not found in scipy.stats module")
-        self._distribution = getattr(scipy_stats_module, distribution)(**kwargs)
-        self._random_state = import_module('numpy.random').RandomState(random_state)
+        if not hasattr(scipy_stats, distribution):
+            raise KeyError("'{}' distribution not found in scipy.stats module".format(distribution))
+        self._distribution = getattr(scipy_stats, distribution)(**kwargs)
+        self._random_state = random.RandomState(random_state)
 
     def evaluate(self):
         """Call `rvs` method of statistical function"""

--- a/spawn/specification/generator_methods.py
+++ b/spawn/specification/generator_methods.py
@@ -17,6 +17,7 @@
 """Generator methods
 """
 import random
+from importlib import import_module
 from spawn.specification.value_proxy import ValueProxy
 
 
@@ -74,3 +75,25 @@ class IncrementalInt(Generator):
         v = self._next_number
         self._next_number += self._step
         return v
+
+
+class ScipyDistribution(Generator):
+    """Generator of values from a statistical distribution in scipy.stats module"""
+    def __init__(self, distribution, **kwargs):
+        """Initialises :class:`ScipyDistribution`
+
+        :param distribution: Name of statistical function that exists in scipy.stats
+        :param kwargs: Arguments to creation of statistical function
+        """
+        try:
+            scipy_stats_module = import_module('scipy.stats')
+        except ImportError as ex:
+            raise ImportError("The scipy module is not installed and therefore the 'scipy.{}'"
+                              " generator cannot be created".format(distribution)) from ex
+        if not hasattr(scipy_stats_module, distribution):
+            raise ValueError("'{}' distribution not found in scipy.stats module")
+        self._distribution = getattr(scipy_stats_module, distribution)(**kwargs)
+
+    def evaluate(self):
+        """Call `rvs` method of statistical function"""
+        return self._distribution.rvs()

--- a/spawn/specification/generator_methods.py
+++ b/spawn/specification/generator_methods.py
@@ -85,7 +85,8 @@ class ScipyDistribution(Generator):
         :param kwargs: Arguments to creation of statistical function
         """
         try:
-            from numpy import random
+            # pylint: disable=import-outside-toplevel
+            from numpy import random as np_random
             from scipy import stats as scipy_stats
         except ImportError as ex:
             raise ImportError("The scipy module is not installed and therefore the 'scipy.{}'"
@@ -93,7 +94,7 @@ class ScipyDistribution(Generator):
         if not hasattr(scipy_stats, distribution):
             raise KeyError("'{}' distribution not found in scipy.stats module".format(distribution))
         self._distribution = getattr(scipy_stats, distribution)(**kwargs)
-        self._random_state = random.RandomState(random_state)
+        self._random_state = np_random.RandomState(random_state)
 
     def evaluate(self):
         """Call `rvs` method of statistical function"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import json
 import pytest
 
 import luigi.configuration
+from scipy import stats as scipy_stats  # avoids strange import err
 
 from spawn.config import DefaultConfiguration
 from spawn.plugins import PluginLoader

--- a/tests/parsers/generator_method_tests.py
+++ b/tests/parsers/generator_method_tests.py
@@ -51,5 +51,5 @@ def test_scipy_uniform():
 
 
 def test_raises_value_error_with_invalid_scipy_distribution():
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         ScipyDistribution('not_a_scipy_distribution')

--- a/tests/parsers/generator_method_tests.py
+++ b/tests/parsers/generator_method_tests.py
@@ -50,6 +50,12 @@ def test_scipy_uniform():
     assert 5.0 <= gen.evaluate() <= 5.1
 
 
+def test_same_random_state_gives_same_value():
+    gen1 = ScipyDistribution('norm', random_state=2, scale=2.0)
+    gen2 = ScipyDistribution('norm', random_state=2, scale=2.0)
+    assert gen1.evaluate() == gen2.evaluate()
+
+
 def test_raises_value_error_with_invalid_scipy_distribution():
     with pytest.raises(KeyError):
         ScipyDistribution('not_a_scipy_distribution')

--- a/tests/parsers/generator_method_tests.py
+++ b/tests/parsers/generator_method_tests.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+import pytest
 from spawn.specification.generator_methods import *
 
 
@@ -42,3 +43,13 @@ def test_incremental_int():
     assert gen.evaluate() == 10
     assert gen.evaluate() == 15
     assert gen.evaluate() == 20
+
+
+def test_scipy_uniform():
+    gen = ScipyDistribution('uniform', loc=5.0, scale=0.1)
+    assert 5.0 <= gen.evaluate() <= 5.1
+
+
+def test_raises_value_error_with_invalid_scipy_distribution():
+    with pytest.raises(ValueError):
+        ScipyDistribution('not_a_scipy_distribution')

--- a/tests/parsers/generator_parser_tests.py
+++ b/tests/parsers/generator_parser_tests.py
@@ -35,6 +35,16 @@ def test_passes_args_correctly():
     assert gens['Gen1'].evaluate() == 52
 
 
+def test_invokes_scipy_uniform_correctly():
+    gen_spec = {'Gen1': {
+        'method': 'scipy.uniform',
+        'loc': 3.0,
+        'scale': 0.1
+    }}
+    gens = GeneratorsParser.default().parse(gen_spec)
+    assert 3.0 <= gens['Gen1'].evaluate() <= 3.1
+
+
 def test_raises_key_error_when_method_not_present():
     with pytest.raises(KeyError):
         GeneratorsParser.default().parse({'Gen1': {'key': 'val'}})

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ extras=
     test
 commands=
     pytest tests --cov spawn
-    pylint spawn
+    pylint spawn --extension-pkg-whitelist=numpy
     licensify LICENSE_SHORT --directory spawn --files *.py --exclude _version.py --check
 
 [testenv:docs]


### PR DESCRIPTION
Allows use of any class from `scipy.stats` as a method for a generator by prefixing the method with `scipy.`. For example:

```JSON
{
  "generators": {
    "Gen1": {
      "method": "scipy.norm",
      "loc": 12.0,
      "scale": 2.5,
      "random_state": 14
    }
  }
}
```

The random state creates a `numpy.random.RandomState` that persists through the life of the generator allowing repeatable generation of values.

Scipy (and numpy) has not been added as an install requirement  but the user is thrown an error if it is not installed when using a scipy generator method.

Closes #112 